### PR TITLE
force gps_baudratep=115200 for HDZero peripheral

### DIFF
--- a/src/js/tabs/ports.js
+++ b/src/js/tabs/ports.js
@@ -307,6 +307,18 @@ TABS.ports.initialize = function (callback, scrollPosition) {
                 functions.push(telemetryFunction);
             }
 
+            //HDZero MSP 1.52
+            if (semver.gte(CONFIG.apiVersion, "1.52.0")) {
+                console.log('debug: peripheral checking');
+                // if peripheral = HDZero then set sensor/gps baud 115200
+                if ($(portConfiguration_e).find('select[name=function-peripherals]').val() === 'HDZERO_OSD') {
+                    console.log('debug: peripheral: '+$(portConfiguration_e).find('select[name=function-peripherals]').val());
+                    //select sensor(gps baudrate) = 115200
+                    $(portConfiguration_e).find('.gps_baudrate').val('115200');
+                    console.log('debug: setting sensor/gps baud to: '+$(portConfiguration_e).find('.gps_baudrate').val());
+                }
+            }
+
             var sensorFunction = $(portConfiguration_e).find('select[name=function-sensors]').val();
             if (sensorFunction) {
                 functions.push(sensorFunction);


### PR DESCRIPTION
* in TESTING, do not merge until feedback
* i dont like this solution, but it does successfully set cli serial to proper values as required by @saidinesh5 's firmware branch

@madchiller , this is a good reason to investigate an "enable-MSP-only" firmware solution.