### PR TITLE
HDZero - fix osd-tab floaty center and third columns

### DIFF
--- a/src/css/tabs/osd.css
+++ b/src/css/tabs/osd.css
@@ -456,7 +456,8 @@ button {
 
 .tab-osd .third_center {
   float: left;
-  width: 32%;
+  /* width: 32%; */
+  width: unset;
   min-width: 350px;
   margin-left: 5px;
   margin-right: 5px;
@@ -466,7 +467,7 @@ button {
     float: left;
 	/* width: calc(50% - 197px);	 */
     width: 32%;
-    max-width: 350px;
+    max-width: 300px;
     margin-left: 20px;
 }
 


### PR DESCRIPTION
* unset center width to fix floaty nature of center and third columns
* narrower third column
![2022-05-14_13-23_fix_floaty_center_and_third_columns](https://user-images.githubusercontent.com/56646290/168444234-25fa67db-abcf-4b37-9d99-42be8d5066d9.png)
